### PR TITLE
add `impl From<std::fs::File> for File`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1063,6 +1063,12 @@ impl std::os::windows::io::AsRawHandle for File {
     }
 }
 
+impl From<std::fs::File> for File {
+    fn from(inner: std::fs::File) -> File {
+        File::new(inner)
+    }
+}
+
 impl AsyncRead for File {
     fn poll_read(
         mut self: Pin<&mut Self>,


### PR DESCRIPTION
Hi,

As stated in the title, this PR adds `impl From<std::fs::File> for async_fs::File` by using the internal `File::new` function. I don't know if there are any hidden gotchas' but I found it useful for integration with other non-async crates, like `tempfile` and so on.